### PR TITLE
fix: bug when have on signer and try add another one

### DIFF
--- a/app/controllers/users/documents_controller.rb
+++ b/app/controllers/users/documents_controller.rb
@@ -8,7 +8,7 @@ class Users::DocumentsController < Users::BaseController
 
   def signers
     @document_signer = DocumentSigner.new
-    @document_signers = @document.signing_members.includes(:document_role)
+    set_document_signers
   end
 
   def add_signer
@@ -95,7 +95,7 @@ class Users::DocumentsController < Users::BaseController
   end
 
   def set_document_signers
-    @document_signers = @document.signers.includes(:document_role)
+    @document_signers = @document.signing_members.includes(:document_role)
   end
 
   def create_document

--- a/test/controllers/users/documents_controller_test.rb
+++ b/test/controllers/users/documents_controller_test.rb
@@ -106,11 +106,23 @@ class Users::DocumentsControllerTest < ActionDispatch::IntegrationTest
           assert_active_link(href: users_documents_path)
         end
 
-        should 'unsuccessfully' do
-          post users_document_add_signer_path(@document), params: { document_signer: { user_id: '' } }
+        should 'unsuccessfully with no signers' do
+          params = { document_signer: { user_id: '', document_role: '' } }
+          post users_document_add_signer_path(@document), params: params
+
           assert_response :success
           @document.reload
           assert_equal 0, @document.signers.count
+        end
+
+        should 'unsuccessfully with signers' do
+          create(:document_signer, user: @user, document: @document, document_role: @document_role)
+          params = { document_signer: { user_id: '', document_role: '' } }
+          post users_document_add_signer_path(@document), params: params
+
+          assert_response :success
+          @document.reload
+          assert_equal 1, @document.signers.count
         end
       end
 


### PR DESCRIPTION
When it has on signer and add another with errors, for example not select the role, it causes 
```ActionView::Template::Error at /users/documents/4/signers
Association named 'document_role' was not found on User; perhaps you misspelled it?
```